### PR TITLE
remove instructions for using public AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following script will create a new AWS VPC (Virtual Private Cloud) configure
 ```
 
 ### Build a base AMI
-We provide a public AMI for the region us-east-1 (ami-ea154180), which is the result of running the following script. To use our public AMI, replace the value of the 'base\_image' variable in 'vars/ec2.yml' with 'ami-ea154180' and do not run the script. The script can take up to an hour to run. If the script fails halfway through (e.g., if you lose a connection to the instance), you can re-run it and it will skip any steps that have already been completed.
+Use the following script to build a base AMI, which can can up to an hour to run. If the script fails halfway through (e.g., if you lose a connection to the instance), you can re-run it and it will skip any steps that have already been completed.
 
 ```bash
 >$ ./build-base.sh

--- a/ec2/build-base.sh
+++ b/ec2/build-base.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script takes 20-30 minutes to run, and creates an image similar to ami-ea154180, which is the public image that we provide for the us-east-1 region.
+# This script takes 20-30 minutes to run, and creates a base image.
 set -e
 ansible-playbook -i ./ec2.py build-start.yml
 ansible-playbook -i ./ec2.py build.yml --tags base


### PR DESCRIPTION
We no longer provide a public base AMI, so remove instructions for using it. The script to build a base AMI is available at `ec2/build-base.sh`.